### PR TITLE
[Bug Fix] Nondeterministic Gift Name

### DIFF
--- a/Src/Danmu.py
+++ b/Src/Danmu.py
@@ -234,13 +234,13 @@ class DanmuRaffleHandler(BaseDanmu):
                 else:
                     raffle_num = 1
                     raffle_name = str_gift
-                broadcast = msg_common.split("广播")[0]
+                broadcast = ''  # This method is abandoned
                 if config["Raffle_Handler"]["TV"] != "False":
                     Log.raffle("%s 号弹幕监控检测到 %s 的 %s 个 %s" % (self._area_id, real_roomid, raffle_num, raffle_name))
                     RaffleHandler.push2queue((real_roomid, raffle_name,), TvRaffleHandler.check)
                     # 如果不是全区就设置为1(分区)
                     broadcast_type = 0 if broadcast == '全区' else 1
-                    Statistics.add2pushed_raffles(raffle_name, broadcast_type, raffle_num)
+                    Statistics.add2pushed_raffles('小电视类', broadcast_type, raffle_num)
             # 大航海
             elif msg_type == 3:
                 raffle_name = msg_common.split("开通了")[-1][:2]


### PR DESCRIPTION
Resolves #33 

Ex:
```
本次推送抽奖统计:
76   X 终极任务‘人在家中坐
44   X 一只猫
65   X ‘没猫铲屎有点愁’
47   X ‘木棍铲屎愁更愁’快去为主子抽口粮
```

(PS) 
Log层面没改 仍是类似`5 号弹幕监控检测到 21245156 的 1 个 ‘木棍铲屎愁更愁’快去为主子抽口粮` 
不过控制台统计归并到`小电视类`里