### PR TITLE
[Bug Fix] 修复开启硬币换银瓜子时出现Python协程报错

### DIFF
--- a/Src/Coin2Silver.py
+++ b/Src/Coin2Silver.py
@@ -33,7 +33,7 @@ class Coin2Silver:
             "csrf_token": account["Token"]["CSRF"]
         }
 
-        data = await AsyncioCurl().request_json("POST", url, headers=config["pcheaders"], data=payload, sign=False)
+        data = await AsyncioCurl().request_json("POST", url, headers=config["pcheaders"], data=payload)
 
         if data["code"] != 0:
             Log.warning(data["message"])


### PR DESCRIPTION
修复开启硬币换银瓜子时出现Python协程报错，临时解决兑换问题
修复 https://github.com/TheWanderingCoel/BiliBiliHelper/issues/35