### PR TITLE
修复签到状态获取

### DIFF
--- a/Src/BasicRequest.py
+++ b/Src/BasicRequest.py
@@ -193,6 +193,12 @@ class BasicRequest:
         return response
 
     @staticmethod
+    async def req_check_signinfo():
+        url = "https://api.live.bilibili.com/sign/GetSignInfo"
+        response = await AsyncioCurl().request_json("GET", url, headers=config["pcheaders"])
+        return response
+
+    @staticmethod
     async def req_send_danmu(msg, roomId):
         url = "https://api.live.bilibili.com/msg/send"
         data = {

--- a/Src/Task.py
+++ b/Src/Task.py
@@ -34,7 +34,7 @@ class Task:
             data = await self.check()
 
             await self.double_watch_info(data)
-            await self.sign_info(data)
+            await self.sign_info()
 
             if len(self.done) >= 2:
                 self.done = []
@@ -51,18 +51,18 @@ class Task:
 
         return data
 
-    async def sign_info(self, value):
-        if len(value["data"]["sign_info"]) == 0:
-            return
+    async def sign_info(self):
         if "sign_info" in self.done:
             return
 
         Log.info("检查任务「每日签到」")
 
-        info = value["data"]["sign_info"]
+        sign_data = await BasicRequest.req_check_signinfo()
+        if not sign_data["code"]:
+            info = sign_data["data"]
 
         if info["status"] == 1:
-            Log.info("「每日签到」奖励已经领取")
+            Log.warning("「每日签到」奖励已经领取")
             self.done.append("sign_info")
             return
 

--- a/Src/Utils.py
+++ b/Src/Utils.py
@@ -154,7 +154,10 @@ class Utils:
         if not data["code"]:
             data = data["data"]
             double_watch_info = data["double_watch_info"]
-            sign_info = data["sign_info"]
+
+        sign_data = await BasicRequest.req_check_signinfo()
+        if not sign_data["code"]:
+            sign_info = sign_data["data"]
 
         if double_watch_info["status"] == 1:
             print("双端观看直播已完成，但未领取奖励")


### PR DESCRIPTION
由于签到接口更换为`https://api.live.bilibili.com/sign/GetSignInfo`，`https://api.live.bilibili.com/i/api/taskInfo`接口无法获取签到信息，故修复，并将签到奖励已领取的log level与双端观看直播已领取的相统一